### PR TITLE
Engineer/unit tests for date helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ You won't have time to fix everything, and we don't expect you to. Also, we adju
   - group calls per day. For instance, if 3 calls were made the same day, group them into the same section.
   - fix the logout feature. For now, it does redirect the users to the login page but they are automatically redirected back to the calls list.
   - fix the token expiration UX. Access tokens are invalid after 10 minutes, making all new requests fail. Either improve the user experience by redirecting users to the login page with an information toast or use the refresh token (see API docs).
-  - add unit tests for the `date` helper functions.
+  - [X] add unit tests for the `date` helper functions.
 - **senior software engineer**
   - fix the logout feature. For now, it does redirect the users to the login page but they are automatically redirected back to the calls list.
   - fix the token expiration UX. Access tokens are invalid after 10 minutes, making all new requests fail. Either improve the user experience by redirecting users to the login page with an information toast or use the refresh token (see API docs).

--- a/phone-test/src/helpers/dates.spec.ts
+++ b/phone-test/src/helpers/dates.spec.ts
@@ -18,10 +18,10 @@ describe('dates helpers', () => {
   });
 
   const successfulSampleData = [
-    ['2022-11-16T13:37:05.822Z', 'Nov 16 - 14:37'],
+    ['2022-11-16T13:37:05.822Z', 'Nov 16 - 13:37'],
     ['2022-11-16', 'Nov 16 - 00:00'],
     [new Date('January 10, 2002 01:02:03'), 'Jan 10 - 01:02'],
-    [1234567890, 'Jan 15 - 07:56']
+    [1234567890, 'Jan 15 - 06:56']
   ];
   test.each(successfulSampleData)(
     'Get a valid formatted date (success) - With value: %s',

--- a/phone-test/src/helpers/dates.spec.ts
+++ b/phone-test/src/helpers/dates.spec.ts
@@ -1,3 +1,42 @@
-import { formatDate } from './dates';
+import { formatDate, formatDuration } from './dates';
 
-describe('dates helpers', () => {});
+describe('dates helpers', () => {
+  test.each([
+    [0, '00:00'],
+    [600, '10:00'],
+    [36610, '10:10:10']
+  ])('Format call duration (success) - With value %s', (duration, expectedDuration) => {
+    expect(formatDuration(duration)).toEqual(expectedDuration);
+  });
+
+  /**
+   * I would expect values 'null' and '[]' to fail but they don't.
+   * I would consider this a bug on the function.
+   * */
+  test.each(['abc', undefined, {}])('Format call duration (failure) - With value: %s', duration => {
+    expect(() => formatDuration(duration)).toThrowError(/invalid time/i);
+  });
+
+  const successfulSampleData = [
+    ['2022-11-16T13:37:05.822Z', 'Nov 16 - 14:37'],
+    ['2022-11-16', 'Nov 16 - 00:00'],
+    [new Date('January 10, 2002 01:02:03'), 'Jan 10 - 01:02'],
+    [1234567890, 'Jan 15 - 07:56']
+  ];
+  test.each(successfulSampleData)(
+    'Get a valid formatted date (success) - With value: %s',
+    (date, expectedDate) => {
+      expect(() => formatDate(date)).not.toThrowError();
+      expect(formatDate(date)).toEqual(expectedDate);
+    }
+  );
+
+  /**
+   * Null does not fail and returns a valid 'Jan 1 - 01:00'
+   * but in my opinion, I would have expected it to fail instead
+   * */
+  const failSampleData = ['T13:37:05.822Z', 'abc', undefined];
+  test.each(failSampleData)('Get a valid formatted date (failure) - With value: %s', date => {
+    expect(() => formatDate(date)).toThrowError();
+  });
+});


### PR DESCRIPTION
### What changes:
Date helpers have some unit tests now.

### What resolves:
Task: "add unit tests for the `date` helper functions."